### PR TITLE
Add Cargo/Rust installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ Before using Memora, you'll need to set up the following:
      - [Together AI](https://www.together.ai/)  
      - [Groq](https://groq.com/)
 
+4. **Cargo/Rust Installation**  
+   Cargo installation is required to build some packages locally
+     - See [Rust website](https://www.rust-lang.org/learn/get-started) for more details.
+     Run the following command in your terminal to install Rust:
+     ```console
+     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+     ```
 
 ## **Installation**
 


### PR DESCRIPTION
While installing memora package in my machine. The following package caused to stop the installation of this package due it required cargo/rust to be installed.

Conflicting package: py-rust-stemmers
