### PR TITLE
Add Kluster.ai as an LLM Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 When we interact with people 🗣️👂, we naturally remember details from past interactions 💭, feelings 😜😢, and shared experiences 🤝. That's what makes us human. **We're bringing this same ability to AI, helping it recall just like us.**
 
-***Give the [github repo](https://github.com/ELZAI/memora/) a starhug ⭐️—it’s feeling a lil’ lonely 🥺***
+***Give the [github repo](https://github.com/ELZAI/memora/) a starhug ⭐️—it's feeling a lil' lonely 🥺***
 
 ## Key Features
 
@@ -51,6 +51,7 @@ Before using Memora, you'll need to set up the following:
      - [Azure OpenAI](https://azure.microsoft.com/en-us/products/cognitive-services/openai-service)  
      - [Together AI](https://www.together.ai/)  
      - [Groq](https://groq.com/)
+     - [Kluster.ai](https://kluster.ai/)
      - Or Integrate Your Own LLM Provider. ([See Docs: Custom LLM Backend](https://elzai.github.io/memora/advanced_usage/#custom-llm-backend))
 
 4. **Optional: Rust/Cargo Setup**  
@@ -226,7 +227,7 @@ recalled_memories, just_memory_ids = await memora.recall_memories_for_message(
 
 # recalled_memories: [
 # Memory(..., memory_id='uuid string', memory="Jake's wife Sarah is due on December 15th", obtained_at=datetime(...), message_sources=[...]),
-# Memory(..., memory_id='uuid string', memory="Jake and Sarah are pretty confident the baby’s a girl but will confirm at the next ultrasound.", obtained_at=datetime(...), message_sources=[...]),  
+# Memory(..., memory_id='uuid string', memory="Jake and Sarah are pretty confident the baby's a girl but will confirm at the next ultrasound.", obtained_at=datetime(...), message_sources=[...]),  
 # ...]
 
 # just_memory_ids: ["uuid string", "uuid string", ...]

--- a/memora/llm_backends/__init__.py
+++ b/memora/llm_backends/__init__.py
@@ -1,11 +1,13 @@
 from .azure_openai_backend_llm import AzureOpenAIBackendLLM
 from .groq_backend_llm import GroqBackendLLM
+from .kluster_backend_llm import KlusterBackendLLM
 from .openai_backend_llm import OpenAIBackendLLM
 from .together_backend_llm import TogetherBackendLLM
 
 __all__ = [
     "AzureOpenAIBackendLLM",
     "GroqBackendLLM",
+    "KlusterBackendLLM",
     "OpenAIBackendLLM",
     "TogetherBackendLLM",
 ]

--- a/memora/llm_backends/kluster_backend_llm.py
+++ b/memora/llm_backends/kluster_backend_llm.py
@@ -1,0 +1,90 @@
+from typing import Any, Dict, List, Type, Union
+
+from openai import AsyncOpenAI
+from pydantic import BaseModel
+from typing_extensions import override
+
+from .base import BaseBackendLLM
+
+
+class KlusterBackendLLM(BaseBackendLLM):
+    """Backend LLM implementation for Kluster.ai API."""
+
+    def __init__(
+        self,
+        api_key: str,
+        model: str = "klusterai/Meta-Llama-3.1-8B-Instruct-Turbo",
+        temperature: float = 0.7,
+        top_p: float = 1,
+        max_tokens: int = 1024,
+        max_retries: int = 3,
+    ):
+        """
+        Initialize the KlusterBackendLLM class with specific parameters.
+
+        Args:
+            api_key (str): The Kluster.ai API key
+            model (str): The name of the Kluster.ai model to use
+            temperature (float): The temperature to use for sampling
+            top_p (float): The top_p value to use for sampling
+            max_tokens (int): The maximum number of tokens to generate
+            max_retries (int): The maximum number of retries to make if a request fails
+        """
+        self.openai_client = AsyncOpenAI(
+            api_key=api_key,
+            base_url="https://api.kluster.ai/v1",
+            max_retries=max_retries,
+        )
+
+        self.model = model
+        self.temperature = temperature
+        self.top_p = top_p
+        self.max_tokens = max_tokens
+
+    @override
+    async def close(self) -> None:
+        """Closes the LLM connection."""
+        await self.openai_client.close()
+        self.openai_client = None
+
+    @override
+    @property
+    def get_model_kwargs(self) -> Dict[str, Any]:
+        """Returns dictionary of model configuration parameters"""
+        return {
+            "model": self.model,
+            "temperature": self.temperature,
+            "top_p": self.top_p,
+            "max_tokens": self.max_tokens,
+        }
+
+    @override
+    async def __call__(
+        self,
+        messages: List[Dict[str, str]],
+        output_schema_model: Type[BaseModel] | None = None,
+    ) -> Union[str, BaseModel]:
+        """
+        Process messages and generate response
+
+        Args:
+            messages (List[Dict[str, str]]): List of message dicts with role and content
+            output_schema_model (Type[BaseModel] | None): Optional Pydantic base model for structured output
+
+        Returns:
+            Union[str, BaseModel]: Generated text response as a string, or an instance of the output schema model if specified
+        """
+        if output_schema_model:
+            response = await self.openai_client.chat.completions.create(
+                messages=messages,
+                **self.get_model_kwargs,
+                response_format={"type": "json_object"},
+            )
+            content = response.choices[0].message.content
+            return output_schema_model.model_validate_json(content)
+        else:
+            response = await self.openai_client.chat.completions.create(
+                messages=messages,
+                **self.get_model_kwargs,
+            )
+            return response.choices[0].message.content 


### PR DESCRIPTION
Add Kluster.ai as an LLM provider. 

kluster.ai is a developer‑centric AI platform with a constantly expanding roster of leading models—Llama 3, DeepSeek‑R1, Gemma 3, Qwen 2.5, and more. 

This PR specifies **klusterai/Meta-Llama-3.1-8B-Instruct-Turbo** but there are a variety of models available to choose from. Full list available here: https://docs.kluster.ai/api-reference/reference/#list-supported-models

Changes:
- Added KlusterBackendLLM implementation
- Updated __init__.py to expose the new provider

The implementation:
- Follows the BaseBackendLLM interface
- Supports both string and structured (Pydantic model) outputs
- Uses the OpenAI client with Kluster.ai's API endpoint
- Includes proper error handling and retries